### PR TITLE
rework to use systemd unit files instead of systemd-run

### DIFF
--- a/systemd_user_context.sh
+++ b/systemd_user_context.sh
@@ -5,28 +5,97 @@
 # Mainly the issue is that a desktop session needs a dedicated dbus,
 # but systemd creates a single one for every logged on user.
 #
-# Using systemd-run it is possible to create a separate systemd-user instance
-# with dedicated XDG_RUNTIME_DIR and DBUS
+# Using systemd-run or a systemd user unit file it is possible to create 
+# a separate systemd-user instance with dedicated XDG_RUNTIME_DIR and DBUS
 #
 # Main ideas in this script by mwsys.mine.bz
 
 # Units to mask in the created instance
 # Uncomment this line and fill in as appropriate for your installation
-#UNITS_TO_MASK="pipewire-pulseaudio.service pipewire-pulseaudio.socket"
+#UNITS_TO_MASK="pipewire-pulse.service pipewire-pulse.socket"
 
 # We're probably going to use file descriptor 1 for output. Stash it away
 # in fd 3 and redirect our fd 1 to stderr to talk to the user
 exec 3>&1 >&2
 
+# prepare user environment
+prepare_user_environment()
+{
+    test -f $XDG_RUNTIME_DIR/systemd/user.control/systemd-session@.service && return
+    install -dm 0700 $XDG_RUNTIME_DIR/systemd/user.control
+    # Create a unit to wait for the target pid to finish
+    {
+        echo "[Unit]"
+        echo "Description=Wait for XRDP session %i to finish"
+        echo "Requires=systemd-session@%i.service"
+        echo "ConditionPathExists=%t/systemd-session-%i/wait-for.pid"
+        echo
+        echo "[Service]"
+        echo "Type=simple"
+        echo "ExecStart=/bin/sh -c 'XRDP_STARTWM_PID=\$(cat %t/systemd-session-%i/wait-for.pid); while /bin/kill -0 \$XRDP_STARTWM_PID 2>/dev/null; do sleep 5; done'"
+        echo "ExecStopPost=/usr/bin/systemctl --user stop systemd-session@%i.service"
+        echo "ExecStopPost=rm -r %t/systemd-session-%i"
+    } >$XDG_RUNTIME_DIR/systemd/user.control/wait-for-systemd-session@.service
+
+    #Create the systemd-user session unit file.
+    {
+        echo "[Unit]"
+        echo "Description=XRDP systemd User Manager for display %i"
+        echo
+        echo "[Service]"
+        echo "Type=notify"
+        echo "ExecStart=sh %t/systemd_user_session.sh systemd-session-%i"
+    } > $XDG_RUNTIME_DIR/systemd/user.control/systemd-session@.service
+    
+    #create the systemd --user wrapper to launch systemd with a clean environment
+    echo '#/bin/sh
+test -z $XDG_RUNTIME_DIR && exit 1
+test -z $1 && exit 1
+
+SESSION_RUNTIME_DIR="$XDG_RUNTIME_DIR/$1"
+install -dm 0700 "$SESSION_RUNTIME_DIR"
+oIFS="$IFS"
+IFS="
+"
+
+# keep only absolutly needed environment variables
+for ev in `env`; do
+    evn=${ev%%=*}
+    [ "$evn" != "HOME" -a \
+      "$evn" != "SHELL" -a \
+      "$evn" != "LANG" -a \
+      "$evn" != "PATH" -a \
+      "$evn" != "SYSTEMD_EXEC_PID" -a \
+      "$evn" != "INVOCATION_ID" -a \
+      "$evn" != "NOTIFY_SOCKET" -a \
+      "$evn" != "MANAGERPID" ] \
+    && unset $evn;
+done
+
+IFS="$oIFS"
+
+XDG_RUNTIME_DIR="$SESSION_RUNTIME_DIR"
+
+export XDG_RUNTIME_DIR
+
+exec /lib/systemd/systemd --user
+' > $XDG_RUNTIME_DIR/systemd_user_session.sh
+    systemctl --user daemon-reload
+}
+
 # -----------------------------------------------------------------------------
 get_unit_name()
 {
+    if [ -z "$XDG_RUNTIME_DIR" ]; then
+        echo "** Warning - no $XDG_RUNTIME_DIR. Using systemd default" >&2
+        XDG_RUNTIME_DIR=/run/user/`id -u`
+    fi
     if [ -z "$DISPLAY" ]; then
         echo "** Warning - no DISPLAY. Assuming test mode" >&2
-        unit_name=xrdp-display-test
+        unit_name=systemd-session@test
     else
-        unit_name=xrdp-display-${DISPLAY##*:} ; # e.g. xrdp-display-10.0
-        unit_name=${unit_name%.*} ; # e.g. xrdp-display-10
+        unit_name=systemd-session@${DISPLAY##*:} ; # e.g. systemd-session@10.0
+        unit_name=${unit_name%.*} ; # e.g. systemd-session@10
     fi
 }
 
@@ -34,7 +103,7 @@ get_unit_name()
 # Param : Unit name
 get_session_runtime_dir()
 {
-    session_runtime_dir=/run/user/`id -u`/$1
+    session_runtime_dir=$XDG_RUNTIME_DIR/${1%%@*}-${1##*@}
 }
 
 # -----------------------------------------------------------------------------
@@ -78,29 +147,14 @@ cmd_init()
             done
         fi
 
-        # Create a unit to wait for the target pid to finish
-        {
-            echo "[Unit]"
-            echo "Description=Wait for XRDP session to finish"
-            echo "Requires=default.target"
-            echo
-            echo "[Service]"
-            echo "Type=simple"
-            echo "ExecStart=/bin/sh -c 'while /bin/kill -0 $target_pid; do sleep 5; done'"
-            echo "ExecStopPost=/usr/bin/systemctl --user exit"
-        } >$session_runtime_dir/systemd/user.control/wait-for-xrdp-session.service
+        prepare_user_environment ;
 
-        # start systemd service. this must be done using systemd-run to get a
-        # proper scope. This mimics user@.service
-        #
-        # Within the system --user process we run wait-for-xrdp-session.service.
-        # That kills the systemd --user instance when the target process
-        # finishes.
-        systemd-run --user -u $unit_name \
-            -E "XDG_RUNTIME_DIR=$session_runtime_dir" \
-            -E "DBUS_SESSION_BUS_ADDRESS=unix:path=$session_runtime_dir/bus" \
-            systemd --user --unit wait-for-xrdp-session.service
-
+        #pass pid to monitor to wait-for- unit
+        echo $target_pid > $session_runtime_dir/wait-for.pid
+        
+        # this will also start systemd-session@
+        systemctl --user start wait-for-$unit_name
+        
         # Use the 'get' command to display the results. We don't need
         # the command to generate any warnings
         cmd_get >/dev/null 2>&1
@@ -112,6 +166,11 @@ cmd_status()
 {
     get_unit_name  ; # Output in 'unit_name'
     systemctl --user status $unit_name >&3
+}
+
+cmd_prepare()
+{
+    prepare_user_environment ;
 }
 
 # -----------------------------------------------------------------------------
@@ -137,13 +196,17 @@ Usage: $0 [ init | get | help ]
             instance for this DISPLAY.
             Does not work within the context created by 'init' or 'get'
 
+    prepare installs systemd.unit files in the current systemd-user context.
+            a custom systemd-user instance may be manually spawned with
+            systemctl --user start systemd-session@<some name>
+
     help    Displays this help
 EOF
 }
 
 # -----------------------------------------------------------------------------
 case "$1" in
-    get | init | status | help)
+    get | init | status | help | prepare)
         func=cmd_$1
         shift
         $func "$@"


### PR DESCRIPTION
add a wrapper to clean up environment to prevent
environtment variable bleeding from the main systemd-user

allow nested nesting (starting Xephyr in Xrdp inside freerdp on the same host with the same user)

the files that get runtime-generated are static. If nest-systemd-user evolves to a package this files should be placed inside /lib/systemd/user and the helper script maybe to /usr/lib(exec?)/nest-systemd-user/

